### PR TITLE
Fix source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "isolatedModules": true,
     "noFallthroughCasesInSwitch": true,
     "declaration": true,
-    "declarationDir": "./dist"
+    "declarationDir": "./dist",
+    "inlineSources": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "rollup.config.js"]


### PR DESCRIPTION
Fixes issue: https://github.com/hotjar/hotjar-js/issues/18

As mentioned in the issue, the problem is that the source maps don't have access to the source code.

## Possible solutions

There are two ways to fix this:
1. (This PR) Add `inlineSources` option in `tsconfig.json` so Rollup can include the source code in the source map files ([explanation](https://github.com/rollup/plugins/issues/260))
2. Include the `src` directory in NPM's published code (i.e. add it to the `files` field in `package.json`).

## Before / After (source map files)

### Before
<img width="1245" alt="Before" src="https://user-images.githubusercontent.com/5723556/231546239-cccfccd8-7a29-4037-87c8-41dfc3fb1782.png">

### After
<img width="1245" alt="After" src="https://user-images.githubusercontent.com/5723556/231546265-db1ff517-f2b6-49ed-9ba0-01c9db45c04c.png">

## Note

I just want to make sure you (the maintainers) know that without fixing this issue, every time this package is used in a Create React App 5 application (or one using `source-map-loader`) these console warnings appear:

<img width="1003" alt="Warnings" src="https://user-images.githubusercontent.com/5723556/231545399-f8548ba2-7e8c-46fd-9122-e1e46bd0e5e7.png">

I know it's "just a warning" and it doesn't prevent applications to build, but it's still degrading the DX for thousands of developers.