### PR TITLE
chore: pin GitHub Actions to ContentSquare org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: ContentSquare/actions-checkout@approved-v2
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v2
+      - uses: ContentSquare/actions-setup-node@approved-v2
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
@@ -31,7 +31,7 @@ jobs:
       - name: Build demo site
         run: npm run build-demo
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: ContentSquare/peaceiris-actions-gh-pages@approved-v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./demo_dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: ContentSquare/actions-checkout@approved-v2
       - run: npm ci
       - run: npm run build
       - run: npm run lint-check


### PR DESCRIPTION
Pin all third-party GitHub Actions to their ContentSquare org mirrors.

Each `uses: <owner>/<action>@<ref>` is replaced with `uses: ContentSquare/<owner>-<action>@approved-<ref>`.