### PR TITLE
chore(ci) migrate Github Actions to Fork-and-Approved-Tag model

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: ContentSquare/actions-checkout@approved-v2
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v2
+      - uses: ContentSquare/actions-setup-node@approved-v2
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
@@ -31,7 +31,7 @@ jobs:
       - name: Build demo site
         run: npm run build-demo
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: ContentSquare/peaceiris-actions-gh-pages@approved-v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./demo_dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: ContentSquare/actions-checkout@approved-v2
       - run: npm ci
       - run: npm run build
       - run: npm run lint-check


### PR DESCRIPTION
# Description

Migrate all GitHub Actions workflow files across ContentSquare repositories to use the Actions Manager Fork-and-Approved-Tag security model.

All direct upstream action references (e.g. `actions/checkout@v4`) have been replaced with their ContentSquare-managed fork equivalents (e.g. `ContentSquare/actions-checkout@approved-v4`) using `platform_github/allowed-actions.yaml` as the source of truth.

## Motivation and Context

The [Actions Manager](https://github.com/ContentSquare/platform_github?tab=readme-ov-file#actions-manager-recommended) implements a Fork-and-Approved-Tag security model to prevent supply chain attacks. Using direct upstream action references bypasses this model and will be blocked by security controls in the future.

This change ensures all workflows use only ContentSquare-controlled forks with security-reviewed approved tags, providing:
- **Supply chain protection**: only ContentSquare-controlled forks are used
- **Approved tags only**: no raw upstream tags
- **Audit trail**: complete approval and usage history

## Breaking Changes

No breaking changes. The ContentSquare fork actions are functionally identical to their upstream counterparts — only the reference syntax changes.

Actions not present in `allowed-actions.yaml` (no approved fork available yet) were left unchanged.

## How Has This Been Tested?

See the following CI runs in this PR
The `Lint GitHub Actions` is an expected error due to an issue on the ruleset